### PR TITLE
Changing access modifier

### DIFF
--- a/java-solutions/ru/ifmo/rain/boger/walk/FNVVisitor.java
+++ b/java-solutions/ru/ifmo/rain/boger/walk/FNVVisitor.java
@@ -13,7 +13,7 @@ public class FNVVisitor extends SimpleFileVisitor<Path> {
     private final int BLOCK_SIZE = 1024;
     private final BufferedWriter writer;
 
-    FNVVisitor(final BufferedWriter writer) {
+    public FNVVisitor(final BufferedWriter writer) {
         this.writer = writer;
     }
 


### PR DESCRIPTION
The constructor is expected to be public because otherwise, the public class cannot be constructed from other packages.